### PR TITLE
Use require_relative instead of require to speed up requires

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,0 @@
-daysUntilLock: 60

--- a/lib/stove/cli.rb
+++ b/lib/stove/cli.rb
@@ -1,5 +1,5 @@
 require 'optparse'
-require 'stove'
+require_relative '../stove'
 
 module Stove
   class Cli

--- a/lib/stove/rake_task.rb
+++ b/lib/stove/rake_task.rb
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/tasklib'
-require 'stove'
+require_relative '../stove'
 
 module Stove
   class RakeTask < Rake::TaskLib


### PR DESCRIPTION
These are faster as they don't have to traverse the filesystem to find
the library

Signed-off-by: Tim Smith <tsmith@chef.io>